### PR TITLE
Improved README.md instructions to refresh provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ Workspace.client.``..``.docs // gives you "/home/project/docs"
 ```
 
 > [!WARNING]
-> At the time of writing, `RelativeFileSystemProvider` does not watch you filesystem for changes. To manually refresh changes, you can do one of the following:
-> * Rebuild the project
+> At the time of writing, `RelativeFileSystemProvider` does not watch you filesystem for changes. To refresh changes, you can do one of the following:
 > * Restart the IDE
+> * Make a change to RelativeFileSystemProvider<"."> to force a refresh
+> * Rebuild the project
 >
 > This is [planned](https://github.com/easybuild-org/EasyBuild.FileSystemProvider/issues/1) to be improved in the future
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Workspace.client.``..``.docs // gives you "/home/project/docs"
 ```
 
 > [!WARNING]
-> At the time of writing, `RelativeFileSystemProvider` does not watch you filesystem for changes. In order for your IDE, to pick changes, you either need to restart it or make a change to `RelativeFileSystemProvider<".">` to force a refresh.
+> At the time of writing, `RelativeFileSystemProvider` does not watch you filesystem for changes. To manually refresh changes, you can do one of the following:
+> * Rebuild the project
+> * Restart the IDE
 >
 > This is [planned](https://github.com/easybuild-org/EasyBuild.FileSystemProvider/issues/1) to be improved in the future
 


### PR DESCRIPTION
When trying to refresh the provider after making changes to the file system, manually editing the path string did not work for me.
However, restarting the IDE definitely works. 
Also, I found that doing a project rebuild consistently works and is faster than restarting the IDE (at least for my project).
(I am using VS Professional.)

