### PR TITLE
Feat - fix #9: AbsoluteFileSystem and RelativeFileSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ EasyBuild.FileSystemProvider is a library that provides a set of F# Type Provide
 
 In every project of mine, I need to orchestrate tasks like building, testing, etc. which involves working with files and directories. The standard way of doing it is by using hardcoded `string` but it is easy to break. You also need to remember what is current working directory or relative path you are working with.
 
-To fix this problem, I created this library that provides 2 F# Type Providers:
+To fix this problem, I created this library that provides 3 F# Type Providers:
 
-- `RelativeFileSystemProvider`, typed representation of files and directories based on your project structure.
+- `RelativeFileSystemProvider`, typed representation of files and directories based on your project structure; outputs relative path strings.
+- `AbsoluteFileSystemProvider`, typed representation of files and directories based on your project structure; outputs absolute path strings.
 - `VirtualFileSystemProvider`, typed representation of files and directories based on a virtual file system.
 
 ### When to use each one?
 
-Use `RelativeFileSystemProvider` when you want to access files and directories that are tracked in your project. For example, you want to access the path of your `fsproj` file or a `public` assets folder.
+Use `RelativeFileSystemProvider`/`AbsoluteFileSystemProvider` when you want to access files and directories that are tracked in your project. For example, you want to access the path of your `fsproj` file or a `public` assets folder.
 
 Use `VirtualFileSystemProvider` when you want to access files and directories that are not tracked in your project. For example, you want to use a destination folder or access a `obj`, `bin` folder.
 
@@ -72,7 +73,7 @@ Workspace.client.``..``.docs // gives you "/home/project/docs"
 ```
 
 > [!WARNING]
-> At the time of writing, `RelativeFileSystemProvider` does not watch you filesystem for changes. To refresh changes, you can do one of the following:
+> At the time of writing, `RelativeFileSystemProvider`/`AbsoluteFileSystemProvider` does not watch you filesystem for changes. To refresh changes, you can do one of the following:
 > * Restart the IDE
 > * Make a change to RelativeFileSystemProvider<"."> to force a refresh
 > * Rebuild the project

--- a/build/Workspace.fs
+++ b/build/Workspace.fs
@@ -7,7 +7,11 @@ let root = __SOURCE_DIRECTORY__ + "/../"
 
 type Workspace = RelativeFileSystem<root>
 
-type VirtualWorkspace = VirtualFileSystem<root, """
+type VirtualWorkspace =
+    VirtualFileSystem<
+        root,
+        """
 src
     bin/
-""">
+"""
+     >

--- a/src/EasyBuild.FileSystemProvider.fsproj
+++ b/src/EasyBuild.FileSystemProvider.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DefineConstants>IS_DESIGNTIME</DefineConstants>
     <!-- This allows the component to execute from 'bin' directory during build -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <Compile Include="ProvidedTypes.fsi" />
     <Compile Include="ProvidedTypes.fs" />
-    <Compile Include="RelativeFileSystemProvider.fs" />
+    <Compile Include="FileSystemProviders.fs" />
     <Compile Include="VirtualFileSystemProvider.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FileSystemProviders.fs
+++ b/src/FileSystemProviders.fs
@@ -1,4 +1,4 @@
-﻿module EasyBuild.FileSystemProvider.AbsoluteFileSystemProviderImpl
+﻿module EasyBuild.FileSystemProvider.FileSystemProviders
 
 open System.Reflection
 open ProviderImplementation.ProvidedTypes
@@ -9,7 +9,8 @@ open System.IO
 let private createFileLiterals
     (directoryInfo: DirectoryInfo)
     (rootType: ProvidedTypeDefinition)
-    (makePath: string -> string) =
+    (makePath: string -> string)
+    =
 
     for file in directoryInfo.EnumerateFiles() do
         let pathFieldLiteral =
@@ -87,12 +88,14 @@ type IFileSystemProvider =
     abstract MakePath: basePath: DirectoryInfo -> targetPath: string -> string
 
 [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
-type FileSystemProviderImpl(config: TypeProviderConfig, implementation: IFileSystemProvider) as this =
+type FileSystemProviderImpl(config: TypeProviderConfig, implementation: IFileSystemProvider) as this
+    =
     inherit TypeProviderForNamespaces(config)
     let namespaceName = "EasyBuild.FileSystemProvider"
     let assembly = Assembly.GetExecutingAssembly()
     let providerName = implementation.ImplementationName
     let makePath = implementation.MakePath
+
     let relativeFileSystem =
         ProvidedTypeDefinition(
             assembly,
@@ -140,21 +143,26 @@ type FileSystemProviderImpl(config: TypeProviderConfig, implementation: IFileSys
 
 [<TypeProvider>]
 type AbsoluteFileSystemProvider(config: TypeProviderConfig) =
-    inherit FileSystemProviderImpl(
-       config, { new IFileSystemProvider with
-       member this.ImplementationName = "AbsoluteFileSystem"
-       member this.MakePath basePath filePath = filePath }
-       )
+    inherit
+        FileSystemProviderImpl(
+            config,
+            { new IFileSystemProvider with
+                member this.ImplementationName = "AbsoluteFileSystem"
+                member this.MakePath basePath filePath = filePath
+            }
+        )
 
 [<TypeProvider>]
 type RelativeFileSystemProvider(config: TypeProviderConfig) =
-    inherit FileSystemProviderImpl(
-        config,
-        { new IFileSystemProvider with
-            member this.ImplementationName = "RelativeFileSystem"
-            member this.MakePath basePath filePath =
-                Path.GetRelativePath(basePath.FullName, filePath)
-                }
+    inherit
+        FileSystemProviderImpl(
+            config,
+            { new IFileSystemProvider with
+                member this.ImplementationName = "RelativeFileSystem"
+
+                member this.MakePath basePath filePath =
+                    Path.GetRelativePath(basePath.FullName, filePath)
+            }
         )
 
 [<assembly: TypeProviderAssembly>]

--- a/src/FileSystemProviders.fs
+++ b/src/FileSystemProviders.fs
@@ -1,4 +1,4 @@
-module EasyBuild.FileSystemProvider.RelativeFileSystemProvider
+﻿module EasyBuild.FileSystemProvider.AbsoluteFileSystemProviderImpl
 
 open System.Reflection
 open ProviderImplementation.ProvidedTypes
@@ -6,11 +6,14 @@ open Microsoft.FSharp.Core.CompilerServices
 
 open System.IO
 
-let private createFileLiterals (directoryInfo: DirectoryInfo) (rootType: ProvidedTypeDefinition) =
+let private createFileLiterals
+    (directoryInfo: DirectoryInfo)
+    (rootType: ProvidedTypeDefinition)
+    (makePath: string -> string) =
 
     for file in directoryInfo.EnumerateFiles() do
         let pathFieldLiteral =
-            ProvidedField.Literal(file.Name, typeof<string>, file.FullName)
+            ProvidedField.Literal(file.Name, typeof<string>, file.FullName |> makePath)
 
         pathFieldLiteral.AddXmlDoc $"Path to '{file.FullName}'"
 
@@ -19,10 +22,11 @@ let private createFileLiterals (directoryInfo: DirectoryInfo) (rootType: Provide
 let rec private createDirectoryProperties
     (directoryInfo: DirectoryInfo)
     (rootType: ProvidedTypeDefinition)
+    (makePath: string -> string)
     =
 
     // Extract the full path in a variable so we can use it in the ToString method
-    let currentFolderFullName = directoryInfo.FullName
+    let currentFolderFullName = directoryInfo.FullName |> makePath
 
     let currentFolderField =
         ProvidedField.Literal(".", typeof<string>, currentFolderFullName)
@@ -43,7 +47,7 @@ let rec private createDirectoryProperties
 
     rootType.AddMember currentFolderField
     rootType.AddMember toStringMethod
-    createFileLiterals directoryInfo rootType
+    createFileLiterals directoryInfo rootType makePath
 
     // Add parent directory
     rootType.AddMemberDelayed(fun () ->
@@ -52,7 +56,7 @@ let rec private createDirectoryProperties
 
         directoryType.AddXmlDoc $"Interface representing directory '{directoryInfo.FullName}'"
 
-        createDirectoryProperties directoryInfo.Parent directoryType
+        createDirectoryProperties directoryInfo.Parent directoryType makePath
         directoryType
     )
 
@@ -65,7 +69,7 @@ let rec private createDirectoryProperties
             folderType.AddXmlDoc $"Interface representing folder '{folder.FullName}'"
 
             // Walk through the folder
-            createDirectoryProperties folder folderType
+            createDirectoryProperties folder folderType makePath
             // Store the folder type in the member
             folderType
         )
@@ -76,18 +80,24 @@ let private watchDir (directoryInfo: DirectoryInfo) =
 
     watcher
 
-[<TypeProvider>]
-type RelativeFileSystemProvider(config: TypeProviderConfig) as this =
-    inherit TypeProviderForNamespaces(config)
+[<Interface>]
+[<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+type IFileSystemProvider =
+    abstract ImplementationName: string
+    abstract MakePath: basePath: DirectoryInfo -> targetPath: string -> string
 
+[<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+type FileSystemProviderImpl(config: TypeProviderConfig, implementation: IFileSystemProvider) as this =
+    inherit TypeProviderForNamespaces(config)
     let namespaceName = "EasyBuild.FileSystemProvider"
     let assembly = Assembly.GetExecutingAssembly()
-
+    let providerName = implementation.ImplementationName
+    let makePath = implementation.MakePath
     let relativeFileSystem =
         ProvidedTypeDefinition(
             assembly,
             namespaceName,
-            "RelativeFileSystem",
+            providerName,
             Some typeof<obj>,
             hideObjectMethods = true
         )
@@ -121,12 +131,31 @@ type RelativeFileSystemProvider(config: TypeProviderConfig) as this =
                         rootType.AddXmlDoc
                             $"Interface representing directory '{rootDirectory.FullName}'"
 
-                        createDirectoryProperties rootDirectory rootType
+                        createDirectoryProperties rootDirectory rootType (rootDirectory |> makePath)
 
                         rootType
         )
 
     do this.AddNamespace(namespaceName, [ relativeFileSystem ])
+
+[<TypeProvider>]
+type AbsoluteFileSystemProvider(config: TypeProviderConfig) =
+    inherit FileSystemProviderImpl(
+       config, { new IFileSystemProvider with
+       member this.ImplementationName = "AbsoluteFileSystem"
+       member this.MakePath basePath filePath = filePath }
+       )
+
+[<TypeProvider>]
+type RelativeFileSystemProvider(config: TypeProviderConfig) =
+    inherit FileSystemProviderImpl(
+        config,
+        { new IFileSystemProvider with
+            member this.ImplementationName = "RelativeFileSystem"
+            member this.MakePath basePath filePath =
+                Path.GetRelativePath(basePath.FullName, filePath)
+                }
+        )
 
 [<assembly: TypeProviderAssembly>]
 do ()

--- a/src/VirtualFileSystemProvider.fs
+++ b/src/VirtualFileSystemProvider.fs
@@ -34,7 +34,7 @@ module Parser =
         /// <returns></returns>
         member this.NormalizedName =
             if this.IsFolder then
-                this.Name + "/"
+                this.Name + string Path.DirectorySeparatorChar
             else
                 this.Name
 
@@ -153,7 +153,7 @@ let private createFileLiteral
     (rootType: ProvidedTypeDefinition)
     =
 
-    let fullPath = rootPath + "/" + inode.Name
+    let fullPath = rootPath + string Path.DirectorySeparatorChar + inode.Name
     let pathFieldLiteral = ProvidedField.Literal(inode.Name, typeof<string>, fullPath)
 
     pathFieldLiteral.AddXmlDoc $"Path to '{fullPath}'"

--- a/tests/AbsoluteFileSystemProvider.fs
+++ b/tests/AbsoluteFileSystemProvider.fs
@@ -1,38 +1,36 @@
-module Tests.RelativeFileSystemProvider
+module Tests.AbsoluteFileSystemProvider
 
 open Expecto
 open Tests.Utils
 open EasyBuild.FileSystemProvider
 open System.IO
 
-type CurrentDirectoryEmptyString = RelativeFileSystem<"">
-type CurrentDirectoryDot = RelativeFileSystem<".">
+type CurrentDirectoryEmptyString = AbsoluteFileSystem<"">
+type CurrentDirectoryDot = AbsoluteFileSystem<".">
 
-type ParentDirectory = RelativeFileSystem<"..">
+type ParentDirectory = AbsoluteFileSystem<"..">
 
-let getRelativePathFor value = Path.GetRelativePath(__SOURCE_DIRECTORY__, value)
 let tests =
     testList
-        "RelativeFileSystemProvider"
+        "AbsoluteFileSystemProvider"
         [
             test "Empty string is mapped to the current directory" {
-                let expected = getRelativePathFor __SOURCE_DIRECTORY__
+                let expected = __SOURCE_DIRECTORY__
                 Expect.equal CurrentDirectoryEmptyString.``.`` expected
             }
 
             test "Dot is mapped to the current directory" {
-                let expected = getRelativePathFor __SOURCE_DIRECTORY__
+                let expected = __SOURCE_DIRECTORY__
                 Expect.equal CurrentDirectoryDot.``.`` expected
             }
 
             test "Double dot is mapped to the parent directory" {
-                let expected' = Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, ".."))
-                let expected = Path.GetRelativePath(expected', expected')
+                let expected = Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, ".."))
                 Expect.equal ParentDirectory.``.`` expected
             }
 
             test "We can navigate the tree upwards" {
-                let expected = getRelativePathFor <| Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "..", "README.md"))
+                let expected = Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "..", "README.md"))
 
                 Expect.equal CurrentDirectoryDot.``..``.src.``..``.``README.md`` expected
             }
@@ -42,17 +40,14 @@ let tests =
                     Path.GetFullPath(
                         Path.Join(__SOURCE_DIRECTORY__, "fixtures", "folder1", "test.txt")
                     )
-                    |> getRelativePathFor
-
                 Expect.equal CurrentDirectoryDot.fixtures.folder1.``test.txt`` expected
             }
 
             test "Directory path can be accessed using ToString()" {
-                let expectedRoot = getRelativePathFor __SOURCE_DIRECTORY__
+                let expectedRoot = __SOURCE_DIRECTORY__
 
                 let expectedFolder1 =
                     Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "fixtures", "folder1"))
-                    |> getRelativePathFor
 
                 Expect.equal (CurrentDirectoryDot.ToString()) expectedRoot
                 Expect.equal (CurrentDirectoryDot.fixtures.folder1.ToString()) expectedFolder1

--- a/tests/AbsoluteFileSystemProvider.fs
+++ b/tests/AbsoluteFileSystemProvider.fs
@@ -40,6 +40,7 @@ let tests =
                     Path.GetFullPath(
                         Path.Join(__SOURCE_DIRECTORY__, "fixtures", "folder1", "test.txt")
                     )
+
                 Expect.equal CurrentDirectoryDot.fixtures.folder1.``test.txt`` expected
             }
 

--- a/tests/EasyBuild.FileSystemProvider.Tests.fsproj
+++ b/tests/EasyBuild.FileSystemProvider.Tests.fsproj
@@ -8,6 +8,7 @@
         <Compile Include="Utils.fs" />
         <Compile Include="VirtualFileSystemProvider.fs" />
         <Compile Include="RelativeFileSystemProvider.fs" />
+        <Compile Include="AbsoluteFileSystemProvider.fs" />
         <Compile Include="Main.fs" />
     </ItemGroup>
     <ItemGroup>

--- a/tests/Main.fs
+++ b/tests/Main.fs
@@ -4,4 +4,10 @@ open Expecto
 
 [<Tests>]
 let tests =
-    testList "All" [ RelativeFileSystemProvider.tests; VirtualFileSystemProvider.tests; AbsoluteFileSystemProvider.tests ]
+    testList
+        "All"
+        [
+            RelativeFileSystemProvider.tests
+            VirtualFileSystemProvider.tests
+            AbsoluteFileSystemProvider.tests
+        ]

--- a/tests/Main.fs
+++ b/tests/Main.fs
@@ -4,4 +4,4 @@ open Expecto
 
 [<Tests>]
 let tests =
-    testList "All" [ RelativeFileSystemProvider.tests; VirtualFileSystemProvider.tests ]
+    testList "All" [ RelativeFileSystemProvider.tests; VirtualFileSystemProvider.tests; AbsoluteFileSystemProvider.tests ]

--- a/tests/RelativeFileSystemProvider.fs
+++ b/tests/RelativeFileSystemProvider.fs
@@ -10,7 +10,9 @@ type CurrentDirectoryDot = RelativeFileSystem<".">
 
 type ParentDirectory = RelativeFileSystem<"..">
 
-let getRelativePathFor value = Path.GetRelativePath(__SOURCE_DIRECTORY__, value)
+let getRelativePathFor value =
+    Path.GetRelativePath(__SOURCE_DIRECTORY__, value)
+
 let tests =
     testList
         "RelativeFileSystemProvider"
@@ -32,7 +34,9 @@ let tests =
             }
 
             test "We can navigate the tree upwards" {
-                let expected = getRelativePathFor <| Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "..", "README.md"))
+                let expected =
+                    getRelativePathFor
+                    <| Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "..", "README.md"))
 
                 Expect.equal CurrentDirectoryDot.``..``.src.``..``.``README.md`` expected
             }

--- a/tests/RelativeFileSystemProvider.fs
+++ b/tests/RelativeFileSystemProvider.fs
@@ -10,7 +10,7 @@ type CurrentDirectoryDot = RelativeFileSystem<".">
 
 type ParentDirectory = RelativeFileSystem<"..">
 
-let getRelativePathFor value =
+let private getRelativePath value =
     Path.GetRelativePath(__SOURCE_DIRECTORY__, value)
 
 let tests =
@@ -18,12 +18,12 @@ let tests =
         "RelativeFileSystemProvider"
         [
             test "Empty string is mapped to the current directory" {
-                let expected = getRelativePathFor __SOURCE_DIRECTORY__
+                let expected = getRelativePath __SOURCE_DIRECTORY__
                 Expect.equal CurrentDirectoryEmptyString.``.`` expected
             }
 
             test "Dot is mapped to the current directory" {
-                let expected = getRelativePathFor __SOURCE_DIRECTORY__
+                let expected = getRelativePath __SOURCE_DIRECTORY__
                 Expect.equal CurrentDirectoryDot.``.`` expected
             }
 
@@ -35,8 +35,8 @@ let tests =
 
             test "We can navigate the tree upwards" {
                 let expected =
-                    getRelativePathFor
-                    <| Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "..", "README.md"))
+                    Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "..", "README.md"))
+                    |> getRelativePath
 
                 Expect.equal CurrentDirectoryDot.``..``.src.``..``.``README.md`` expected
             }
@@ -46,17 +46,17 @@ let tests =
                     Path.GetFullPath(
                         Path.Join(__SOURCE_DIRECTORY__, "fixtures", "folder1", "test.txt")
                     )
-                    |> getRelativePathFor
+                    |> getRelativePath
 
                 Expect.equal CurrentDirectoryDot.fixtures.folder1.``test.txt`` expected
             }
 
             test "Directory path can be accessed using ToString()" {
-                let expectedRoot = getRelativePathFor __SOURCE_DIRECTORY__
+                let expectedRoot = getRelativePath __SOURCE_DIRECTORY__
 
                 let expectedFolder1 =
                     Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "fixtures", "folder1"))
-                    |> getRelativePathFor
+                    |> getRelativePath
 
                 Expect.equal (CurrentDirectoryDot.ToString()) expectedRoot
                 Expect.equal (CurrentDirectoryDot.fixtures.folder1.ToString()) expectedFolder1


### PR DESCRIPTION
BREAKING: net6.0 over netstandard2.0 (netstandard2.1 is minimum for `Path.GetRelativePath`)

BREAKING: Name of RelativeFileSystem would provide different strings, but they still point to the same files.

ie: tests will break, but behaviour will be the same.

PS: Please squash; I had made these changes on my branch before realising you had closed the last one!