### PR TITLE
feat: Simplified access to DirectoryInfo object from TP

### DIFF
--- a/src/FileSystemProviders.fs
+++ b/src/FileSystemProviders.fs
@@ -48,6 +48,30 @@ let rec private createDirectoryProperties
 
     rootType.AddMember currentFolderField
     rootType.AddMember toStringMethod
+
+    // Provide pregenerated access to DirectoryInfo to provide access to other
+    // helpers without requiring us to construct them all in the type provider
+    let getDirectoryInfo =
+        let currentFolderFullName = <@@ currentFolderFullName @@>
+
+        let method =
+            ProvidedMethod(
+                "GetDirectoryInfo",
+                [],
+                typeof<DirectoryInfo>,
+                isStatic = true,
+                invokeCode =
+                    fun args -> <@@ let dir = DirectoryInfo(%%currentFolderFullName) in dir @@>
+            )
+
+        method.AddXmlDoc(
+            """<summary>Retrieves the <c>DirectoryInfo</c> object for the current directory.</summary>
+<returns>The current directory <c>DirectoryInfo</c> object"""
+        )
+
+        method
+
+    rootType.AddMember getDirectoryInfo
     createFileLiterals directoryInfo rootType makePath
 
     // Add parent directory

--- a/tests/AbsoluteFileSystemProvider.fs
+++ b/tests/AbsoluteFileSystemProvider.fs
@@ -55,11 +55,24 @@ let tests =
             }
 
             test "DirectoryInfo accessible from GetDirectoryInfo()" {
-                let expected = DirectoryInfo(__SOURCE_DIRECTORY__)
-                Expect.equal (CurrentDirectoryDot.GetDirectoryInfo().FullName) expected.FullName
+                let expectedSourceDir = DirectoryInfo(__SOURCE_DIRECTORY__)
+                let actualSourceDir = CurrentDirectoryDot.GetDirectoryInfo()
+                Expect.equal (actualSourceDir.FullName) expectedSourceDir.FullName
 
                 Expect.equal
-                    (CurrentDirectoryDot.GetDirectoryInfo().EnumerateDirectories() |> Seq.length)
-                    (expected.GetDirectories() |> Seq.length)
+                    (actualSourceDir.EnumerateDirectories() |> Seq.length)
+                    (expectedSourceDir.GetDirectories() |> Seq.length)
+
+                let expectedFixturesFolder =
+                    Path.Join(__SOURCE_DIRECTORY__, "fixtures") |> DirectoryInfo
+
+                let actualFixturesFolder = CurrentDirectoryDot.fixtures.GetDirectoryInfo()
+
+                Expect.equal (actualFixturesFolder.FullName) expectedFixturesFolder.FullName
+
+                Expect.equal
+                    (actualFixturesFolder.EnumerateDirectories() |> Seq.length)
+                    (expectedFixturesFolder.GetDirectories() |> Seq.length)
             }
+
         ]

--- a/tests/AbsoluteFileSystemProvider.fs
+++ b/tests/AbsoluteFileSystemProvider.fs
@@ -53,4 +53,13 @@ let tests =
                 Expect.equal (CurrentDirectoryDot.ToString()) expectedRoot
                 Expect.equal (CurrentDirectoryDot.fixtures.folder1.ToString()) expectedFolder1
             }
+
+            test "DirectoryInfo accessible from GetDirectoryInfo()" {
+                let expected = DirectoryInfo(__SOURCE_DIRECTORY__)
+                Expect.equal (CurrentDirectoryDot.GetDirectoryInfo().FullName) expected.FullName
+
+                Expect.equal
+                    (CurrentDirectoryDot.GetDirectoryInfo().EnumerateDirectories() |> Seq.length)
+                    (expected.GetDirectories() |> Seq.length)
+            }
         ]

--- a/tests/EasyBuild.FileSystemProvider.Tests.fsproj
+++ b/tests/EasyBuild.FileSystemProvider.Tests.fsproj
@@ -19,4 +19,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
       <PackageReference Include="YoloDev.Expecto.TestSdk" />
     </ItemGroup>
+    <ItemGroup>
+        <None Include="fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
 </Project>

--- a/tests/RelativeFileSystemProvider.fs
+++ b/tests/RelativeFileSystemProvider.fs
@@ -57,16 +57,31 @@ let tests =
                     Path.GetFullPath(Path.Join(__SOURCE_DIRECTORY__, "fixtures", "folder1"))
                     |> getRelativePath
 
+                let test = CurrentDirectoryDot.ToString()
+
                 Expect.equal (CurrentDirectoryDot.ToString()) expectedRoot
                 Expect.equal (CurrentDirectoryDot.fixtures.folder1.ToString()) expectedFolder1
             }
 
             test "DirectoryInfo accessible from GetDirectoryInfo()" {
-                let expected = DirectoryInfo(__SOURCE_DIRECTORY__)
-                Expect.equal (CurrentDirectoryDot.GetDirectoryInfo().FullName) expected.FullName
+                let expectedWorkingDir = DirectoryInfo(System.Environment.CurrentDirectory)
+                let actualWorkingDir = CurrentDirectoryDot.GetDirectoryInfo()
+                Expect.equal (actualWorkingDir.FullName) expectedWorkingDir.FullName
 
                 Expect.equal
-                    (CurrentDirectoryDot.GetDirectoryInfo().EnumerateDirectories() |> Seq.length)
-                    (expected.GetDirectories() |> Seq.length)
+                    (actualWorkingDir.EnumerateDirectories() |> Seq.length)
+                    (expectedWorkingDir.GetDirectories() |> Seq.length)
+
+                let expectedFixturesFolder =
+                    Path.Join(System.Environment.CurrentDirectory, "fixtures") |> DirectoryInfo
+
+                let actualFixturesFolder = CurrentDirectoryDot.fixtures.GetDirectoryInfo()
+
+                Expect.equal (actualFixturesFolder.FullName) expectedFixturesFolder.FullName
+
+                Expect.equal
+                    (actualFixturesFolder.EnumerateDirectories() |> Seq.length)
+                    (expectedFixturesFolder.GetDirectories() |> Seq.length)
             }
+
         ]

--- a/tests/RelativeFileSystemProvider.fs
+++ b/tests/RelativeFileSystemProvider.fs
@@ -7,7 +7,6 @@ open System.IO
 
 type CurrentDirectoryEmptyString = RelativeFileSystem<"">
 type CurrentDirectoryDot = RelativeFileSystem<".">
-
 type ParentDirectory = RelativeFileSystem<"..">
 
 let private getRelativePath value =
@@ -60,5 +59,14 @@ let tests =
 
                 Expect.equal (CurrentDirectoryDot.ToString()) expectedRoot
                 Expect.equal (CurrentDirectoryDot.fixtures.folder1.ToString()) expectedFolder1
+            }
+
+            test "DirectoryInfo accessible from GetDirectoryInfo()" {
+                let expected = DirectoryInfo(__SOURCE_DIRECTORY__)
+                Expect.equal (CurrentDirectoryDot.GetDirectoryInfo().FullName) expected.FullName
+
+                Expect.equal
+                    (CurrentDirectoryDot.GetDirectoryInfo().EnumerateDirectories() |> Seq.length)
+                    (expected.GetDirectories() |> Seq.length)
             }
         ]


### PR DESCRIPTION
Hi,

This pull would add a simple helper to quickly instantiate the DirectoryInfo object from the type provider, allowing streamlined access to utilities such as EnumerateDirectories etc.

## Alternatives

This isn't necessary to provide; users can pretty easily create a function that does this.

I'm not fazed if this doesn't get accepted.

## Help Required

One test fails, and it fails only for the RelativeFileSystem:

```fs
test "DirectoryInfo accessible from GetDirectoryInfo()" {
    let expected = DirectoryInfo(__SOURCE_DIRECTORY__)
    Expect.equal (CurrentDirectoryDot.GetDirectoryInfo().FullName) expected.FullName

    Expect.equal
        (CurrentDirectoryDot.GetDirectoryInfo().EnumerateDirectories() |> Seq.length)
        (expected.GetDirectories() |> Seq.length)
}
```

```ansi
EasyBuild: Working directory: tests
EasyBuild: C:\Program Files\dotnet\dotnet.EXE test
Restore complete (0.5s)
  EasyBuild.FileSystemProvider succeeded (0.2s) → C:\Users\shaya\RiderProjects\EasyBuild.FileSystemProvider\src\bin\Debug\net6.0\EasyBuild.FileSystemProvider.dll
  EasyBuild.FileSystemProvider.Tests succeeded (2.0s) → bin\Debug\net8.0\EasyBuild.FileSystemProvider.Tests.dll
  EasyBuild.FileSystemProvider.Tests test failed with 1 error(s) (0.8s)
    C:\Program Files\dotnet\sdk\9.0.301\Microsoft.TestPlatform.targets(48,5): error TESTERROR:
      All.RelativeFileSystemProvider.DirectoryInfo accessible from GetDirectoryInfo() (44ms): Error Message:
      . String actual was longer than expected, at pos 63 found item '\\'.
      expected: C:\Users\shaya\RiderProjects\EasyBuild.FileSystemProvider\tests
        actual: C:\Users\shaya\RiderProjects\EasyBuild.FileSystemProvider\tests\bin\Debug\net8.0
         at Tests.Utils.Expect.equal[a](a actual, a expected) in C:\Users\shaya\RiderProjects\EasyBuild.FileSystemProvid
      er\tests\Utils.fs:line 7
         at Tests.RelativeFileSystemProvider.tests@65-14.Invoke(Unit unitVar) in C:\Users\shaya\RiderProjects\EasyBuild.
      FileSystemProvider\tests\RelativeFileSystemProvider.fs:line 66
         at Expecto.Impl.execTestAsync@566-1.Invoke(Unit unitVar)
         at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1,
      FSharpFunc`2 part2) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 510
         at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\asyn
      c.fs:line 112

Test summary: total: 22, failed: 1, succeeded: 21, skipped: 0, duration: 0.8s
```

### What this implies

The absolute file directory has no issue. The issue must be related to the evaluation of the directory relative string. However, why doesn't this occur in other tests?